### PR TITLE
Display loading state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import { useStateWithStorage } from './utils';
 
 export function App() {
 	const [data, setData] = useState([]);
+	const [isLoading, setIsLoading] = useState(true);
 
 	/**
 	 * Here, we're using a custom hook to create `listToken` and a function
@@ -72,6 +73,7 @@ export function App() {
 
 			/** Finally, we update our React state. */
 			setData(nextData);
+			setIsLoading(false);
 		});
 	}, [listToken]);
 
@@ -99,7 +101,7 @@ export function App() {
 							!listToken ? (
 								<Navigate to="/" />
 							) : (
-								<List data={data} listToken={listToken} />
+								<List data={data} listToken={listToken} isLoading={isLoading} />
 							)
 						}
 					/>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -19,7 +19,7 @@ export function ListItem({ listToken, item }) {
 				isChecked: false,
 			});
 		}
-	}, [item]);
+	}, [item, listToken]);
 
 	const handleChange = useCallback(async () => {
 		if (!item.isChecked) {
@@ -28,7 +28,6 @@ export function ListItem({ listToken, item }) {
 			await updateItem(listToken, item);
 		}
 	}, [listToken, item]);
-
 
 	const getTextColor = () => {
 		if (item?.currentEstimate <= 7) {
@@ -61,7 +60,6 @@ export function ListItem({ listToken, item }) {
 			await deleteItem(listToken, id);
 		}
 	};
-
 
 	return (
 		<>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ListItem } from '../components';
 
-export function List({ data, listToken }) {
+export function List({ data, listToken, isLoading }) {
 	const navigate = useNavigate();
 	const [searchItem, setSearchItem] = useState('');
 
@@ -32,7 +32,9 @@ export function List({ data, listToken }) {
 
 	return (
 		<>
-			{data.length ? (
+			{isLoading ? (
+				'Loading...'
+			) : data.length ? (
 				<>
 					<form>
 						<label htmlFor="filter_items">Filter items </label>


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description
Added a loading state that will display when our data is fetching.  We also added listToken as a dependency to the handleChange function in the listItem.jsx file. 
<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue
Closes #34 
<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria
- [x] A loading state is visible while the list items are fetching and the message 'Your shopping list is currently empty' only appears when a new list is created. <!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|  ✓   | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->

### After
![image](https://user-images.githubusercontent.com/57120467/202468546-a543904d-44fe-4727-bc98-5c6bb084b3c4.png)

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria
1. From your terminal, do `git checkout main`
2. Pull down this branch with `git pull origin kl-md-set-loading-state`
3. Checkout the branch with `git checkout kl-md-set-loading-state`
4.  From the UI in the list view, click on the 'create a new list' button and you will see the loading state in action
<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
